### PR TITLE
Workaround for Syncing Cinematics

### DIFF
--- a/xlive/Blam/Engine/Objects/Objects.h
+++ b/xlive/Blam/Engine/Objects/Objects.h
@@ -169,7 +169,7 @@ struct s_unit_data_definition : s_object_data_definition
 	DWORD field_130;
 	datum simulation_actor_index;
 	DWORD unit_flags;		  //(unit_data->unit_flags & 8) != 0   -->active_camo_active
-							  //unit_data->unit_flags |= 2         -->unit_is_alive
+	//unit_data->unit_flags |= 2         -->unit_is_alive
 	e_object_team unit_team;
 	char pad[3];
 	datum controlling_player_index;
@@ -323,6 +323,7 @@ namespace Engine::Objects
 	bool object_has_animation_manager(const datum object_index);
 	void object_compute_node_matrices_with_children(const datum object_datum);
 	real_matrix4x3* object_get_node_matrix(const datum object_datum, const __int16 node_index);
+	unsigned int object_index_from_name_index(datum obj_index);
 
 	int object_get_count();
 	int object_count_from_iter();

--- a/xlive/Blam/Engine/hs/networked_hs_handler/networked_hs_handler_client.cpp
+++ b/xlive/Blam/Engine/hs/networked_hs_handler/networked_hs_handler_client.cpp
@@ -6,12 +6,14 @@
 #include "Blam/Engine/cutscene/cinematics.h"
 #include "Blam/Engine/devices/devices.h"
 #include "Blam/Engine/Simulation/simulation_world.h"
+#include "H2MOD/Modules/OnScreenDebug/OnscreenDebug.h"
 
 // Stores all the functions recieved from the host
 static std::list<s_networked_hs_function> g_hs_client_function_backlog;
 
 // Table of functions to execute depending on hs function type
 static networked_hs_functions_table_t networked_hs_function_table[e_hs_function::_e_hs_function_size];
+static int itr = 1;
 
 void initialize_networked_hs_function_table()
 {
@@ -147,13 +149,18 @@ networked_hs_functions_table_t get_networked_hs_lamda_function(const e_hs_functi
 		return [](const s_networked_hs_function* data)
 		{
 			s_hs_custom_animation_relative_args* args = (s_hs_custom_animation_relative_args*)data->arg_buffer;
-			args->object = simulation_gamestate_entity_get_object_index(args->object);
-			args->relative_object = simulation_gamestate_entity_get_object_index(args->relative_object);
-
+			addDebugText("[HSC Print] Client custom_animation_relative( %d, %08X ,  %08X , %d ,  %d)", args->object, args->animation_path, args->animation, args->interpolates_into_animation, args->relative_object);
+			addDebugText("[HSC Print] Client custom_animation_relative (name index : %d , %08X),", args->object, Engine::Objects::object_index_from_name_index(args->object));
+			args->object = Engine::Objects::object_index_from_name_index(args->object);
+			args->relative_object = Engine::Objects::object_index_from_name_index(args->relative_object);
+			/*if(itr==2)
+			__debugbreak();
+			*/
 			if (!custom_animation_relative(args->object, args->animation_path, args->animation, args->interpolates_into_animation, args->relative_object))
 			{
 				print_to_console("custom_animation_relative returned false on clients, this is very bad!!!!");
 			}
+			itr++;
 		};
 	}
 	case e_hs_function_object_cinematic_lod:

--- a/xlive/Blam/Engine/hs/networked_hs_handler/networked_hs_handler_host.cpp
+++ b/xlive/Blam/Engine/hs/networked_hs_handler/networked_hs_handler_host.cpp
@@ -3,6 +3,7 @@
 
 #include "Blam/Engine/Game/GameGlobals.h"
 #include "Blam/Engine/Networking/NetworkMessageTypeCollection.h"
+#include "H2MOD/Modules/OnScreenDebug/OnscreenDebug.h"
 
 static modify_hs_arguments_table_t modify_hs_arguments_table[e_hs_function::_e_hs_function_size];
 
@@ -113,10 +114,13 @@ modify_hs_arguments_table_t get_modify_lamda_function(const e_hs_function functi
 			const s_object_data_definition* relative_object = object_get_fast_unsafe(args->relative_object);
 
 			if (args->object == DATUM_INDEX_NONE) { return; }
-			args->object = object->simulation_entity_index;
+			args->object = object->name_list_index;
 
 			if (args->relative_object == DATUM_INDEX_NONE) { return; }
-			args->relative_object = relative_object->simulation_entity_index;
+			args->relative_object = relative_object->name_list_index;
+
+			addDebugText("[HSC Print] Host custom_animation_relative( %d, %08X ,  %08X , %d ,  %d)", args->object, args->animation_path, args->animation, args->interpolates_into_animation, args->relative_object);
+			addDebugText("[HSC Print] Host custom_animation_relative (name index : %d , %08X ),", object->name_list_index, Engine::Objects::object_index_from_name_index(object->name_list_index));
 		};
 	}
 	case e_hs_function_ai_play_line_on_object:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26570896/230741158-bf2bbe64-f5a0-4769-9c83-08505cf62ed5.png)


* Fixes an issue where cinematic objects were spawning at global_origin on client side
* Reference objects used by **custom_animation_relative** are not necessarily in the entity_database and need to be referenced some other way that is consistent across server and client , so had to use **object_name_list_index**
* Adding that resulted in some objects working but others didnt work due to a race-condition in the game engine
* Game syncs simulation_objects using network_send /network_update functions that runs in a separate loop from game_tick()
* While current script-synchronization uses hs_update() that runs inside game_tick() so some scripts have potential to run before objects are actually created like  **custom_animation_relative**
* Using modulo 5 inside hs_update() on clients can mitigate this race-condition but not actually fix it
```C
if (time_globals::get_game_time() % 5 == 0)
client_execute_stored_hs_commands();
```
A better fix is required
